### PR TITLE
hotfix: roundRobin

### DIFF
--- a/db.go
+++ b/db.go
@@ -287,5 +287,5 @@ func (dbImpl *DBImpl) rounRobin(n int) int {
 	if n <= 1 {
 		return 0
 	}
-	return int(1 + (atomic.AddUint64(&dbImpl.replicasCount, 1) % uint64(n)))
+	return int((atomic.AddUint64(&dbImpl.replicasCount, 1) % uint64(n)))
 }


### PR DESCRIPTION
Out of bound robins generated by the method causing the pkg to panic