### PR TITLE
Configurable interface to check query type to detect RETURNING

### DIFF
--- a/options.go
+++ b/options.go
@@ -16,10 +16,11 @@ const (
 
 // Option define the option property
 type Option struct {
-	PrimaryDBs []*sql.DB
-	ReplicaDBs []*sql.DB
-	StmtLB     StmtLoadBalancer
-	DBLB       DBLoadBalancer
+	PrimaryDBs       []*sql.DB
+	ReplicaDBs       []*sql.DB
+	StmtLB           StmtLoadBalancer
+	DBLB             DBLoadBalancer
+	QueryTypeChecker QueryTypeChecker
 }
 
 // OptionFunc used for option chaining
@@ -36,6 +37,14 @@ func WithPrimaryDBs(primaryDBs ...*sql.DB) OptionFunc {
 func WithReplicaDBs(replicaDBs ...*sql.DB) OptionFunc {
 	return func(opt *Option) {
 		opt.ReplicaDBs = replicaDBs
+	}
+}
+
+// WithQueryTypeChecker sets the query type checker instance.
+// The default one just checks for the presence of the string "RETURNING" in the uppercase query.
+func WithQueryTypeChecker(checker QueryTypeChecker) OptionFunc {
+	return func(opt *Option) {
+		opt.QueryTypeChecker = checker
 	}
 }
 
@@ -61,7 +70,8 @@ func WithLoadBalancer(lb LoadBalancerPolicy) OptionFunc {
 
 func defaultOption() *Option {
 	return &Option{
-		DBLB:   &RoundRobinLoadBalancer[*sql.DB]{},
-		StmtLB: &RoundRobinLoadBalancer[*sql.Stmt]{},
+		DBLB:             &RoundRobinLoadBalancer[*sql.DB]{},
+		StmtLB:           &RoundRobinLoadBalancer[*sql.Stmt]{},
+		QueryTypeChecker: &DefaultQueryTypeChecker{},
 	}
 }

--- a/query.go
+++ b/query.go
@@ -1,0 +1,28 @@
+package dbresolver
+
+import "strings"
+
+type QueryType int
+
+const (
+	QueryTypeUnknown QueryType = iota
+	QueryTypeRead
+	QueryTypeWrite
+)
+
+// QueryTypeChecker is used to try to detect the query type, like for detecting RETURNING clauses in
+// INSERT/UPDATE clauses.
+type QueryTypeChecker interface {
+	Check(query string) QueryType
+}
+
+// DefaultQueryTypeChecker searches for a "RETURNING" string inside the query to detect a write query.
+type DefaultQueryTypeChecker struct {
+}
+
+func (c DefaultQueryTypeChecker) Check(query string) QueryType {
+	if strings.Contains(strings.ToUpper(query), "RETURNING") {
+		return QueryTypeWrite
+	}
+	return QueryTypeUnknown
+}

--- a/resolver.go
+++ b/resolver.go
@@ -16,5 +16,6 @@ func New(opts ...OptionFunc) DB {
 		replicas:         opt.ReplicaDBs,
 		loadBalancer:     opt.DBLB,
 		stmtLoadBalancer: opt.StmtLB,
+		queryTypeChecker: opt.QueryTypeChecker,
 	}
 }


### PR DESCRIPTION
This PR creates a configurable interface instead of just checking for "RETURNING" inside the query string.