### PR TITLE
fix: deadlocks in Random Lb

### DIFF
--- a/.github/workflows/go_cross.yml
+++ b/.github/workflows/go_cross.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [ '1.18.x', '1.19.x', '1.20.x']
+        go-version: [ '1.18.x', '1.19.x', '1.20.x', '1.21.x']
         arch: [ x64, arm, arm64 ]
         os: [ macos-latest, ubuntu-latest ] #windows-latest
 

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -30,9 +30,9 @@ func (lb RandomLoadBalancer[T]) Name() LoadBalancerPolicy {
 }
 
 // Resolve return the resolved option for Random LB.
-// Marked with go:noinline to prevent inlining.
+// Marked with go:nosplit to prevent preemption.
 //
-//go:noinline
+//go:nosplit
 func (lb RandomLoadBalancer[T]) Resolve(dbs []T) T {
 	if len(lb.randInt) == 0 {
 		lb.predict(len(dbs))

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -29,7 +29,8 @@ func (lb RandomLoadBalancer[T]) Name() LoadBalancerPolicy {
 	return RandomLB
 }
 
-// Resolve return the resolved option for Random LB
+// Resolve return the resolved option for Random LB.
+// Cannot be preempted
 //
 //go:nosplit
 func (lb RandomLoadBalancer[T]) Resolve(dbs []T) T {

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -55,7 +55,7 @@ type RoundRobinLoadBalancer[T DBConnection] struct {
 	counter uint64 // Monotonically incrementing counter on every call
 }
 
-// RandomLoadBalancer return the LB policy name
+// Name return the LB policy name
 func (lb RoundRobinLoadBalancer[T]) Name() LoadBalancerPolicy {
 	return RoundRobinLB
 }

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -70,11 +70,11 @@ func (lb *RoundRobinLoadBalancer[T]) roundRobin(n int) int {
 	return int(atomic.AddUint64(&lb.counter, 1) % uint64(n))
 }
 
-// nolint
+//nolint
 func (lb *RoundRobinLoadBalancer[T]) predict(n int) int {
 	if n <= 1 {
 		return 0
 	}
 	counter := lb.counter
-	return int(atomic.AddUint64(&counter, 1) % uint64(n))
+	return int(atomic.AddUint64(&counter, 1) % uint64(n)
 }

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -31,10 +31,9 @@ func (lb RandomLoadBalancer[T]) Name() LoadBalancerPolicy {
 
 // Resolve return the resolved option for Random LB
 func (lb RandomLoadBalancer[T]) Resolve(dbs []T) T {
-	if len(lb.randInt) == 0 {
+	for len(lb.randInt) == 0 {
 		lb.predict(len(dbs))
 	}
-
 	randomInt := <-lb.randInt
 	return dbs[randomInt]
 }
@@ -71,7 +70,7 @@ func (lb *RoundRobinLoadBalancer[T]) roundRobin(n int) int {
 	return int(atomic.AddUint64(&lb.counter, 1) % uint64(n))
 }
 
-//nolint
+// nolint
 func (lb *RoundRobinLoadBalancer[T]) predict(n int) int {
 	if n <= 1 {
 		return 0

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -31,10 +31,10 @@ func (lb RandomLoadBalancer[T]) Name() LoadBalancerPolicy {
 
 // Resolve return the resolved option for Random LB
 func (lb RandomLoadBalancer[T]) Resolve(dbs []T) T {
-	for len(lb.randInt) == 0 {
-		lb.predict(len(dbs))
-	}
-	randomInt := <-lb.randInt
+	defer func() {
+		<-lb.randInt
+	}()
+	randomInt := lb.predict(len(dbs))
 	return dbs[randomInt]
 }
 
@@ -70,11 +70,11 @@ func (lb *RoundRobinLoadBalancer[T]) roundRobin(n int) int {
 	return int(atomic.AddUint64(&lb.counter, 1) % uint64(n))
 }
 
-//nolint
+// nolint
 func (lb *RoundRobinLoadBalancer[T]) predict(n int) int {
 	if n <= 1 {
 		return 0
 	}
 	counter := lb.counter
-	return int(atomic.AddUint64(&counter, 1) % uint64(n)
+	return int(atomic.AddUint64(&counter, 1) % uint64(n))
 }

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -37,7 +37,6 @@ func (lb RandomLoadBalancer[T]) Resolve(dbs []T) T {
 	if len(lb.randInt) == 0 {
 		lb.predict(len(dbs))
 	}
-
 	randomInt := <-lb.randInt
 	return dbs[randomInt]
 }

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -31,10 +31,10 @@ func (lb RandomLoadBalancer[T]) Name() LoadBalancerPolicy {
 
 // Resolve return the resolved option for Random LB
 func (lb RandomLoadBalancer[T]) Resolve(dbs []T) T {
-	defer func() {
-		<-lb.randInt
-	}()
-	randomInt := lb.predict(len(dbs))
+	for len(lb.randInt) == 0 {
+		lb.predict(len(dbs))
+	}
+	randomInt := <-lb.randInt
 	return dbs[randomInt]
 }
 

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -36,10 +36,9 @@ func (lb RandomLoadBalancer[T]) Resolve(dbs []T) T {
 	if len(lb.randInt) == 0 {
 		lb.predict(len(dbs))
 	}
-	select {
-	case randomIt := <-lb.randInt:
-		return dbs[randomIt]
-	}
+
+	randomInt := <-lb.randInt
+	return dbs[randomInt]
 }
 
 func (lb RandomLoadBalancer[T]) predict(n int) int {

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -30,9 +30,9 @@ func (lb RandomLoadBalancer[T]) Name() LoadBalancerPolicy {
 }
 
 // Resolve return the resolved option for Random LB.
-// Marked with go:nosplit to prevent inlining.
+// Marked with go:noinline to prevent inlining.
 //
-//go:nosplit
+//go:noinline
 func (lb RandomLoadBalancer[T]) Resolve(dbs []T) T {
 	if len(lb.randInt) == 0 {
 		lb.predict(len(dbs))

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -30,7 +30,7 @@ func (lb RandomLoadBalancer[T]) Name() LoadBalancerPolicy {
 }
 
 // Resolve return the resolved option for Random LB.
-// Cannot be preempted
+// Marked with go:nosplit to prevent inlining.
 //
 //go:nosplit
 func (lb RandomLoadBalancer[T]) Resolve(dbs []T) T {

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -33,11 +33,12 @@ func (lb RandomLoadBalancer[T]) Name() LoadBalancerPolicy {
 //
 //go:nosplit
 func (lb RandomLoadBalancer[T]) Resolve(dbs []T) T {
+	if len(lb.randInt) == 0 {
+		lb.predict(len(dbs))
+	}
 	select {
 	case randomIt := <-lb.randInt:
 		return dbs[randomIt]
-	case lb.randInt <- lb.predict(len(dbs)):
-		return dbs[<-lb.randInt]
 	}
 }
 

--- a/loadbalancer.go
+++ b/loadbalancer.go
@@ -70,7 +70,6 @@ func (lb *RoundRobinLoadBalancer[T]) roundRobin(n int) int {
 	return int(atomic.AddUint64(&lb.counter, 1) % uint64(n))
 }
 
-// nolint
 func (lb *RoundRobinLoadBalancer[T]) predict(n int) int {
 	if n <= 1 {
 		return 0


### PR DESCRIPTION
Fix: #44

Deadlock could occur after **inlining** or **preemption** of the **Random-LB Method: Resolve** in a multithreading scenario. 

CC: @bxcodec 